### PR TITLE
Add VSCode debug profile

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Launch Chrome",
+      "url": "http://localhost:5173",
+      "webRoot": "${workspaceFolder}"
+    }
+  ]
+}


### PR DESCRIPTION
This is a pretty gnarly problem area to understand. Let's make it easier for folks by adding a debugging profile to make it easy to set breakpoints for the UI via VSCode's launch configuration. 

For those of you using neovim, I've read you can use [nvim-dap](https://github.com/mfussenegger/nvim-dap) to hook into the [debug adapter protocol](https://microsoft.github.io/debug-adapter-protocol/) to reuse the same config. I haven't tested that so ymmv. 