### PR TITLE
WIP Exploration of JSR type aquisition

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -162,28 +162,11 @@ ${debugLinks
           debugLinks.push([resolvedUrl.url, redirectedUrl]);
           typescriptEnvironment.createFile(
             urlToFilepath(resolvedUrl.url),
-
-            // export * from … doesn't re-export default exports. But we
-            // want to re-export default exports. So we have turned
-            // allowSyntheticDefaultImports on, which makes the next
-            // line of code work, but on the other hand, doesn't _actually_
-            // work in Deno because they don't support the option because
-            // Node.js doesn't support the option in their native ESM
-            // loading strategy.
-            //
-            // So, if we can find a way to essentially "link" or "redirect"
-            // typescript modules other than this one, let's switch,
-            // but for now this lets us do a sort of 'transparent' redirect
-            // from one val to another.
-            //
-            // The purpose of this whole redirecting dance is because of relative
-            // paths: when you import from a url that is a redirect, and the
-            // code that's at that path uses relative paths, we need to resolve
-            // those relative paths relative to the final resolved url, not the
-            // initial one.
-            //
-            // https://github.com/denoland/deno/issues/17058
-            `export * from '${redirectedUrl}'; import e from '${redirectedUrl}'; export default e;`,
+            `
+            declare module '${importSpecifier}' {
+              ${importedCode}
+            }
+            `,
           );
         }
 


### PR DESCRIPTION
>[!NOTE]
> This isn't intended to be merged. It's just going to be a record of my exploration. 

---

I've started digging deeper into JSR type acquisition and what would be required to support JSR types. I need to dig more into what Deno's doing in their LSP...

I explored how @nandorojo was constructing his examples in #5. With the change I have below I've been able to get my [webview](https://jsr.io/@justbe/webview) package running successfully. 


```
import { createWebView } from "jsr:@justbe/webview"
```

I was hoping it'd be just that simple (wouldn't that be a treat?). That works in _some_ cases with relatively simple type declarations. I've got several other things I tired: switching how I handled declarations depending on if the declaration file was a global declaration or a module declaration (determined by if there's a top level export), separating out the imports and exports and only wrapping the exports in a declaration. 

I need to spend more time with it. The biggest thing I think would be helpful is to be able to grab the diagnostics of these generated type files. Downstream type checking is failing so the compilers bail at a certain point and we get whatever it seems to have made it through. There's got to be a better way to get signal about _why_ these modules aren't loading. I'm going to look at it more this week. @orta if you have thoughts, I'd love to hear them!